### PR TITLE
USB string lengths should not include trailing zero

### DIFF
--- a/mtk/avr/bootloaders/caterina/Descriptors.c
+++ b/mtk/avr/bootloaders/caterina/Descriptors.c
@@ -191,13 +191,13 @@ const USB_Descriptor_String_t LanguageString =
  */
 const USB_Descriptor_String_t ProductString =
 {
-	.Header                 = {.Size = USB_STRING_LEN(22), .Type = DTYPE_String},
+	.Header                 = {.Size = USB_STRING_LEN(21), .Type = DTYPE_String},
 	.UnicodeString			= L"LinkIt Smart 7688 Duo"
 };
 
 const USB_Descriptor_String_t ManufNameString = 
 {
-	.Header					= {.Size = USB_STRING_LEN(14), .Type = DTYPE_String},
+	.Header					= {.Size = USB_STRING_LEN(13), .Type = DTYPE_String},
 	.UnicodeString			= L"MediaTek Labs"
 };
 


### PR DESCRIPTION
The declared length of the USB names is one too high. Check the lengths of the strings in https://github.com/sparkfun/Arduino_Boards/blob/master/sparkfun/avr/bootloaders/caterina/Descriptors.c 
